### PR TITLE
feat(ci): add GitHub Actions build workflow + fix pigen Linux compat

### DIFF
--- a/.buildScript/pigen_watch.ps1
+++ b/.buildScript/pigen_watch.ps1
@@ -1,4 +1,8 @@
 ﻿# 修复控制台和脚本编码
+param(
+    [switch]$Once
+)
+
 $OutputEncoding = [System.Text.Encoding]::UTF8
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 [Console]::InputEncoding = [System.Text.Encoding]::UTF8
@@ -62,6 +66,12 @@ class ${className}NativeImpl(val context: Context) : ${className}Native {
 }
 
 Get-ChildItem -Path $PIGEON_DIR -Filter *.dart -Recurse | ForEach-Object { Run-Pigeon $_.FullName }
+
+if ($Once) {
+    Write-Host "`n>>> [Once] Initial codegen complete, skipping watcher." -ForegroundColor Green
+    return
+}
+
 Write-Host "`n>>> [Watcher] Watching $PIGEON_DIR for changes..." -ForegroundColor Yellow
 $watcher = New-Object System.IO.FileSystemWatcher
 $watcher.Path = (Get-Item $PIGEON_DIR).FullName

--- a/.buildScript/pigen_watch.ps1
+++ b/.buildScript/pigen_watch.ps1
@@ -12,6 +12,18 @@ $DART_OUT_DIR = "lib/generated"
 $KOTLIN_SRC_ROOT = "android/app/src/main/kotlin"
 $BASE_PACKAGE = "com.jsxposed.x"
 
+# 大小写无关地查找已存在文件,保留开发者手工指定的大小写
+# (Windows FS 不敏感,Linux 敏感;不做这层兜底会在 Linux 旁边生成第二个重复文件)
+function Get-PreservedCaseName {
+    param($dir, $expectedName)
+    if (-not (Test-Path $dir -PathType Container)) { return $expectedName }
+    $existing = Get-ChildItem -Path $dir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ieq $expectedName } |
+        Select-Object -First 1
+    if ($existing) { return $existing.Name }
+    return $expectedName
+}
+
 function Run-Pigeon {
     param($file)
     
@@ -36,8 +48,10 @@ function Run-Pigeon {
         if ($_) { $className += "$([char]::ToUpper($_[0]))$($_.Substring(1))" }
     }
 
-    $kotlin_file = "$kotlin_out_dir/${className}Native.g.kt"
-    $impl_file = "$kotlin_out_dir/${className}NativeImpl.kt"
+    $kotlinFileName = Get-PreservedCaseName $kotlin_out_dir "${className}Native.g.kt"
+    $implFileName   = Get-PreservedCaseName $kotlin_out_dir "${className}NativeImpl.kt"
+    $kotlin_file = "$kotlin_out_dir/$kotlinFileName"
+    $impl_file = "$kotlin_out_dir/$implFileName"
 
     Write-Host "`n>>> [Generating] $fileName" -ForegroundColor Cyan
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - 'v*'
+      - 'V*'
   pull_request:
     branches:
       - master
@@ -48,7 +48,7 @@ jobs:
           $ref     = '${{ github.ref }}'
           $inFlav  = '${{ github.event.inputs.flavor }}'
           $inType  = '${{ github.event.inputs.build_type }}'
-          $isTag   = $ref.StartsWith('refs/tags/v')
+          $isTag   = $ref.StartsWith('refs/tags/V')
 
           switch ($event) {
             'workflow_dispatch' {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ on:
           - release
           - both
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 env:
   FLUTTER_VERSION: '3.41.9'
   JAVA_VERSION: '17'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,162 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Xposed flavor to build'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - api100
+          - api101
+          - both
+      build_type:
+        description: 'Build type'
+        required: true
+        default: 'release'
+        type: choice
+        options:
+          - debug
+          - release
+          - both
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FLUTTER_VERSION: '3.41.9'
+  JAVA_VERSION: '17'
+
+jobs:
+  matrix:
+    name: Resolve build matrix
+    runs-on: windows-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - id: compute
+        shell: pwsh
+        run: |
+          $event   = '${{ github.event_name }}'
+          $ref     = '${{ github.ref }}'
+          $inFlav  = '${{ github.event.inputs.flavor }}'
+          $inType  = '${{ github.event.inputs.build_type }}'
+          $isTag   = $ref.StartsWith('refs/tags/v')
+
+          switch ($event) {
+            'workflow_dispatch' {
+              $flavors = if ($inFlav -eq 'both') { @('api100','api101') } else { @($inFlav) }
+              $types   = if ($inType -eq 'both') { @('debug','release') } else { @($inType) }
+            }
+            'pull_request' {
+              $flavors = @('api100','api101')
+              $types   = @('debug')
+            }
+            'push' {
+              if ($isTag) {
+                $flavors = @('api100','api101')
+                $types   = @('release')
+              } else {
+                $flavors = @('api100','api101')
+                $types   = @('debug')
+              }
+            }
+            default {
+              $flavors = @('api100')
+              $types   = @('debug')
+            }
+          }
+
+          $include = @()
+          foreach ($f in $flavors) {
+            foreach ($t in $types) {
+              $include += [ordered]@{ flavor = $f; build_type = $t }
+            }
+          }
+          $json = ConvertTo-Json -Compress -Depth 4 -InputObject @($include)
+          "include=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Resolved matrix: $json"
+
+  build:
+    name: Build ${{ matrix.flavor }} ${{ matrix.build_type }}
+    needs: matrix
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.matrix.outputs.include) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+
+      - name: Setup Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Disable Aliyun maven mirrors (CI workspace only)
+        shell: pwsh
+        run: |
+          $files = @(
+            'android/build.gradle.kts',
+            'android/settings.gradle.kts'
+          )
+          foreach ($file in $files) {
+            if (-not (Test-Path $file)) { continue }
+            $content = Get-Content -Raw -Path $file
+            $cleaned = [regex]::Replace(
+              $content,
+              '(?ms)\s*maven\s*\{\s*url\s*=\s*uri\(\s*"https://maven\.aliyun\.com/[^"]*"\s*\)\s*\}',
+              ''
+            )
+            Set-Content -Path $file -Value $cleaned -NoNewline -Encoding UTF8
+            Write-Host "Stripped aliyun mirrors from $file"
+          }
+          $remaining = Select-String -Path $files -Pattern 'aliyun' -SimpleMatch
+          if ($remaining) {
+            Write-Error "Aliyun references still present after strip:"
+            $remaining | ForEach-Object { Write-Error "  $($_.Path):$($_.LineNumber)  $($_.Line.Trim())" }
+            exit 1
+          }
+          Write-Host "OK - no aliyun references remain."
+
+      - name: flutter pub get
+        shell: pwsh
+        run: flutter pub get
+
+      - name: Pigeon codegen (one-shot)
+        shell: pwsh
+        run: .\.buildScript\pigen_watch.ps1 -Once
+
+      - name: Build APK (${{ matrix.flavor }} / ${{ matrix.build_type }})
+        shell: pwsh
+        run: flutter build apk --flavor ${{ matrix.flavor }} --${{ matrix.build_type }}
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ matrix.flavor }}-${{ matrix.build_type }}
+          path: build/app/outputs/flutter-apk/app-${{ matrix.flavor }}-${{ matrix.build_type }}.apk
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   matrix:
     name: Resolve build matrix
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     outputs:
       include: ${{ steps.compute.outputs.include }}
     steps:
@@ -91,7 +91,7 @@ jobs:
   build:
     name: Build ${{ matrix.flavor }} ${{ matrix.build_type }}
     needs: matrix
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -100,20 +100,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: gradle
-
-      - name: Setup Flutter ${{ env.FLUTTER_VERSION }}
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
 
       - name: Disable Aliyun maven mirrors (CI workspace only)
         shell: pwsh
@@ -141,13 +127,27 @@ jobs:
           }
           Write-Host "OK - no aliyun references remain."
 
+      - name: Setup JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+
+      - name: Setup Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
       - name: flutter pub get
         shell: pwsh
         run: flutter pub get
 
       - name: Pigeon codegen (one-shot)
         shell: pwsh
-        run: .\.buildScript\pigen_watch.ps1 -Once
+        run: ./.buildScript/pigen_watch.ps1 -Once
 
       - name: Build APK (${{ matrix.flavor }} / ${{ matrix.build_type }})
         shell: pwsh
@@ -160,3 +160,11 @@ jobs:
           path: build/app/outputs/flutter-apk/app-${{ matrix.flavor }}-${{ matrix.build_type }}.apk
           if-no-files-found: error
           retention-days: 30
+
+      - name: Stop Gradle daemon (release cache locks before post-job save)
+        if: always()
+        shell: bash
+        run: |
+          if [ -f android/gradlew ]; then
+            (cd android && bash ./gradlew --stop) || true
+          fi


### PR DESCRIPTION
  ## Summary

  - 新增 `.github/workflows/build.yml`:Ubuntu runner + Flutter 3.41.9 + JDK 17,在 push / tag / PR / 手动 dispatch
  上触发,按事件类型展开 `{flavor} × {build_type}` matrix 并上传 APK artifact
  - CI workspace 内剥离 `android/build.gradle.kts` 和 `android/settings.gradle.kts` 里的 aliyun 镜像源(仓库源文件不动),让 GitHub runner
  走 `google()` / `mavenCentral()`;strip 步骤刻意放在 setup-java **之前**,保证 Gradle 缓存 key(`*.gradle*`
  文件哈希)在多次运行间稳定,从第二次跑开始能命中缓存
  - 修复 `pigen_watch.ps1` 在 Linux 大小写敏感 FS 下的 bug:`lsposed.dart` 脚本默认输出 `LsposedNative.g.kt`,但仓库手工命名是
  `LSPosedNative.g.kt`,Linux 会两个文件并存触发 Kotlin redeclaration。加 `Get-PreservedCaseName` 做大小写无关查找,沿用已有文件名;Windows
   行为保持不变
  - 顺带给 `pigen_watch.ps1` 加 `-Once` switch,让 CI 一次性 codegen 后退出,不进 watcher 死循环